### PR TITLE
C++20 / gcc 10 fix: remove allocator::destroy call

### DIFF
--- a/kdtree++/allocator.hpp
+++ b/kdtree++/allocator.hpp
@@ -74,7 +74,11 @@ namespace KDTree
       void
       _M_destroy_node(_Node_* __p)
       {
+#if __cplusplus >= 201703L
+        std::allocator_traits<allocator_type>::destroy(_M_node_allocator,__p);
+#else
         _M_node_allocator.destroy(__p);
+#endif
       }
     };
 


### PR DESCRIPTION
std::allocator::destroy was deprecated in C++17 and removed in C++20 (https://en.cppreference.com/w/cpp/memory/allocator/destroy).
Its replacement std::allocator_traits<T>::destroy was introduced in C++11 (https://en.cppreference.com/w/cpp/memory/allocator_traits/destroy).
This conditionally compiled fix enables code to compile with gcc 10+ or any C++20-compliant compiler.