### PR TITLE
Fix compilation warnings

### DIFF
--- a/examples/test_hayne.cpp
+++ b/examples/test_hayne.cpp
@@ -32,15 +32,22 @@ struct duplet
    value_type d[2];
 };
 
-typedef KDTree::KDTree<2, duplet, std::pointer_to_binary_function<duplet,int,double> > duplet_tree_type;
+#if __cplusplus < 201103L || (defined(_MSC_VER) && _MSC_VER <= 1900)
+typedef KDTree::KDTree<2, duplet, std::pointer_to_binary_function<duplet, int, double> > duplet_tree_type;
+#else
+typedef KDTree::KDTree<2, duplet, std::function<double(duplet, int)> > duplet_tree_type;
+#endif
 
 inline double return_dup( duplet d, int k ) { return d[k]; }
 
-
-
 int main()
 {
-   duplet_tree_type dupl_tree_test(std::ptr_fun(return_dup));
+   #if __cplusplus < 201103L || (defined(_MSC_VER) && _MSC_VER <= 1900)
+       duplet_tree_type dupl_tree_test(std::ptr_fun(return_dup));
+   #else
+       duplet_tree_type dupl_tree_test(std::ref(return_dup));
+       //duplet_tree_type std::function<double(duplet, int)> dupl_tree_test = return_dup;
+   #endif
    std::vector<duplet> vDuplets;
 
    //srand(time(0));
@@ -70,12 +77,8 @@ int main()
 
    dupl_tree_test.optimise();
 
-   size_t elements;
-
    while (vDuplets.size() > 0) //delete all duplets from tree which are in the vector
    {
-      elements = vDuplets.size();
-
       duplet element_to_erase = vDuplets.back();
       vDuplets.pop_back();
 

--- a/examples/test_kdtree.cpp
+++ b/examples/test_kdtree.cpp
@@ -101,8 +101,11 @@ struct alternate_tac
    double operator()( alternate_triplet const& t, size_t k ) const { return t[k]; }
 };
 
-
-typedef KDTree::KDTree<3, triplet, std::pointer_to_binary_function<triplet,size_t,double> > tree_type;
+#if __cplusplus < 201103L || (defined(_MSC_VER) && _MSC_VER <= 1900)
+    typedef KDTree::KDTree<3, triplet, std::pointer_to_binary_function<triplet, size_t, double> > tree_type;
+#else
+    typedef KDTree::KDTree<3, triplet, std::function<double(triplet, int)> > tree_type;
+#endif
 
 struct Predicate
 {
@@ -122,7 +125,7 @@ int main()
 {
    // check that it'll find nodes exactly MAX away
    {
-      tree_type exact_dist(std::ptr_fun(tac));
+      tree_type exact_dist(std::ref(tac));
         triplet c0(5, 4, 0);
         exact_dist.insert(c0);
         triplet target(7,4,0);
@@ -159,7 +162,7 @@ int main()
 
 
    {
-      tree_type exact_dist(std::ptr_fun(tac));
+      tree_type exact_dist(std::ref(tac));
         triplet c0(5, 2, 0);
         exact_dist.insert(c0);
         triplet target(7,4,0);
@@ -172,7 +175,7 @@ int main()
    }
 
    {
-      tree_type exact_dist(std::ptr_fun(tac));
+      tree_type exact_dist(std::ref(tac));
         triplet c0(5, 2, 0);
         exact_dist.insert(c0);
         triplet target(7,4,0);
@@ -183,7 +186,7 @@ int main()
       assert(found.second == std::sqrt(8));
    }
 
-  tree_type src(std::ptr_fun(tac));
+  tree_type src(std::ref(tac));
 
   triplet c0(5, 4, 0); src.insert(c0);
   triplet c1(4, 2, 1); src.insert(c1);
@@ -382,7 +385,7 @@ int main()
   // Walter reported that the find_within_range() wasn't giving results that were within
   // the specified range... this is the test.
   {
-     tree_type tree(std::ptr_fun(tac));
+     tree_type tree(std::ref(tac));
      tree.insert( triplet(28.771200,16.921600,-2.665970) );
      tree.insert( triplet(28.553101,18.649700,-2.155560) );
      tree.insert( triplet(28.107500,20.341400,-1.188940) );

--- a/kdtree++/kdtree.hpp
+++ b/kdtree++/kdtree.hpp
@@ -1214,7 +1214,6 @@ protected:
     o << "dimensions:  " << __K << std::endl;
 
     typedef KDTree<__K, _Val, _Acc, _Dist, _Cmp, _Alloc> _Tree;
-    typedef typename _Tree::_Link_type _Link_type;
 
     std::stack<_Link_const_type> s;
     s.push(tree._M_get_root());


### PR DESCRIPTION
# Goal
Fix all compilation warning when using a recent compiler or >= C++11 when compiling [FreeCAD](https://github.com/FreeCAD/FreeCAD/) with this repository (I am moving a shadow copy of the old repository into a GIT submodule)

# DEV Description
- Features `std::pointer_to_binary_function` and `std::ptr_fun` are deprecated since C++11 and were remove in C++17. This triggers many compilation warning when using a recent compiler. See [cppreference => std::pointer_to_binary_function](https://en.cppreference.com/w/cpp/utility/functional/pointer_to_binary_function) and [cppreference => std::ptr_fun](https://en.cppreference.com/w/cpp/utility/functional/ptr_fun) which were replaced by `std::function` and `std::ref`

- Removal of useless debug local variable (see `elements`)

- Removal of unused `typedef typename _Tree::_Link_type _Link_type`

# Notice
This PR is still backward compatible with older  C++ versions if needed.

