### PR TITLE
Bump CMake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5)
 project (libkdtree CXX)
 
 option (BUILD_PYTHON_BINDINGS "Build Python bindings (requires SWIG)")


### PR DESCRIPTION
The recently released CMake 4 drops support below CMake 3.5, causing a build failure if the minimum required version is specified below 3.5.

This commit just bumps the minimum version; project still builds fine.

Reported in Debian in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1113165