### PR TITLE
Close file handles properly

### DIFF
--- a/python-bindings/gen-swig-hpp.py
+++ b/python-bindings/gen-swig-hpp.py
@@ -183,8 +183,10 @@ def write_swig_file(tmpl_fn_name, swig_fn_name):
     TMPL_BODY = "\n\n".join(TMPL_BODY_LIST)
 
     # write swig file
-    i_content = open(tmpl_fn_name, "r").read()
+    f = open(tmpl_fn_name, "r")
+    i_content = f.read()
     i_content = i_content.replace("%%TMPL_BODY%%", TMPL_BODY).replace("%%TMPL_PY_CLASS_DEF%%", "\n".join(TMPL_PY_CLASS))
+    f.close()
     f=open(swig_fn_name, "w")
     f.write(i_content)
     f.close()


### PR DESCRIPTION
Debian is carrying several patches, I'm forwarding those patches to you (upstream), maybe you want to include them.

The patch is from here: 
https://salsa.debian.org/debian/libkdtreepp/-/blob/master/debian/patches/close-file-handles.patch?ref_type=heads

Authorship information
Origin: written by Sebastian Ramacher <sramacher@debian.org>
Forwarded: http://lists.alioth.debian.org/pipermail/libkdtree-devel/2012-October/000363.html
